### PR TITLE
Update linting to ruff and python style

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,22 +42,22 @@ jobs:
     - name: Install linting tools
       run: |
         source venv/bin/activate
-        pip install black>=23.0.0 isort>=5.12.0 flake8>=6.0.0 mypy>=1.5.0
+        pip install ruff>=0.5.0 isort>=5.12.0 mypy>=1.5.0
 
-    - name: Check code formatting with Black
+    - name: Check code formatting with Ruff
       run: |
         source venv/bin/activate
-        black --check --line-length=120 --diff src/ tests/
+        ruff format --check --diff src/ tests/
 
     - name: Check import sorting with isort
       run: |
         source venv/bin/activate
         isort --check-only --diff --line-length=120 --profile=black src/ tests/
 
-    - name: Check PEP 8 compliance with flake8
+    - name: Lint with Ruff
       run: |
         source venv/bin/activate
-        flake8 --max-line-length=120 --extend-ignore=E203,W503 src/ tests/
+        ruff check src/ tests/
 
     - name: Type checking with mypy
       run: |
@@ -84,7 +84,7 @@ jobs:
         python -m venv venv
         source venv/bin/activate
         python -m pip install --upgrade pip
-        pip install black>=23.0.0 isort>=5.12.0
+        pip install ruff>=0.5.0 isort>=5.12.0
 
     - name: Auto-format suggestion (dry run)
       run: |
@@ -93,6 +93,6 @@ jobs:
         echo "If formatting issues are found, run these commands locally:" >> $GITHUB_STEP_SUMMARY
         echo '```bash' >> $GITHUB_STEP_SUMMARY
         echo "source venv/bin/activate" >> $GITHUB_STEP_SUMMARY
-        echo "black --line-length=120 src/ tests/" >> $GITHUB_STEP_SUMMARY
+        echo "ruff format --line-length=120 src/ tests/" >> $GITHUB_STEP_SUMMARY
         echo "isort --line-length=120 --profile=black src/ tests/" >> $GITHUB_STEP_SUMMARY
         echo '```' >> $GITHUB_STEP_SUMMARY 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,8 +1,3 @@
-[tool.black]
-line-length = 120
-target-version = ['py310']
-include = '\.pyi?$'
-
 [tool.isort]
 profile = "black"
 line_length = 120
@@ -14,5 +9,7 @@ python_files = "test_*.py"
 [tool.ruff]
 line-length = 120
 target-version = "py310"
-select = ["E", "F", "W", "I", "B", "C4", "ARG", "SIM"]
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "B", "C4", "ARG", "SIM"]
 ignore = ["E203", "E501"] 


### PR DESCRIPTION
Reconfigure Python linting to use Ruff, replacing Black and Flake8, and update the CI workflow accordingly.

---
<a href="https://cursor.com/background-agent?bcId=bc-fbed67e6-d032-4264-8137-11e3de53af91">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fbed67e6-d032-4264-8137-11e3de53af91">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

